### PR TITLE
Abbreviate astral surrogate ranges

### DIFF
--- a/lib/character_set/shared_methods.rb
+++ b/lib/character_set/shared_methods.rb
@@ -86,6 +86,10 @@ class CharacterSet
           Writer.write(ranges, opts, &block)
         end
 
+        def to_s_with_surrogate_ranges
+          Writer.write_surrogate_ranges(bmp_part.ranges, astral_part.ranges)
+        end
+
         def to_s_with_surrogate_alternation
           Writer.write_surrogate_alternation(bmp_part.ranges, astral_part.ranges)
         end

--- a/lib/character_set/writer.rb
+++ b/lib/character_set/writer.rb
@@ -13,6 +13,25 @@ class CharacterSet
       opts[:in_brackets] ? "[#{content}]" : content
     end
 
+    def write_surrogate_ranges(bmp_ranges, astral_ranges)
+      bmp_set = write(bmp_ranges, format: :js, in_brackets: true)
+      return bmp_set if astral_ranges.empty?
+      bmp_set = nil if bmp_ranges.empty?
+
+      astral_set = astral_ranges.map do |range|
+        if range.size > 2
+          min, max = range.minmax
+          minh, minl = surrogate_pair(min)
+          maxh, maxl = surrogate_pair(max)
+          (minh == maxh ? minh : "[#{minh}-#{maxh}]") + \
+            (minl == maxl ? minl : "[#{minl}-#{maxl}]")
+        else
+          surrogate_pairs([range])
+        end
+      end
+      "(?:#{(astral_set + [bmp_set]).compact * '|'})"
+    end
+
     def write_surrogate_alternation(bmp_ranges, astral_ranges)
       bmp_set = write(bmp_ranges, format: :js, in_brackets: true)
       if astral_ranges.empty?
@@ -24,14 +43,14 @@ class CharacterSet
     end
 
     def surrogate_pairs(astral_ranges)
-      astral_ranges.flat_map { |range| range.map { |cp| surrogate_pair(cp) } }
+      astral_ranges.flat_map { |range| range.map { |cp| surrogate_pair(cp).join } }
     end
 
     def surrogate_pair(astral_codepoint)
       base = astral_codepoint - 0x10000
       high = ((base / 1024).floor + 0xD800).to_s(16)
       low  = (base % 1024 + 0xDC00).to_s(16)
-      "\\u#{high}\\u#{low}"
+      ["\\u#{high}", "\\u#{low}"]
     end
   end
 end

--- a/spec/character_set/to_s_with_surrogate_ranges_spec.rb
+++ b/spec/character_set/to_s_with_surrogate_ranges_spec.rb
@@ -1,0 +1,16 @@
+shared_examples :character_set_to_s_with_surrogate_ranges do |variant|
+  it 'calls CharacterSet::Writer::write_surrogate_ranges' do
+    expect(CharacterSet::Writer)
+      .to receive(:write_surrogate_ranges)
+      .and_return(42)
+    expect(variant[].to_s_with_surrogate_ranges).to eq 42
+  end
+end
+
+describe "CharacterSet#to_s_with_surrogate_ranges" do
+  it_behaves_like :character_set_to_s_with_surrogate_ranges, CharacterSet
+end
+
+describe "CharacterSet::Pure#to_s_with_surrogate_ranges" do
+  it_behaves_like :character_set_to_s_with_surrogate_ranges, CharacterSet::Pure
+end


### PR DESCRIPTION
At least JavaScript and C# by default have regex engines that operate on
UTF16 units not Unicode codepoints.  Therefore, on these engines, it is
possible to get full astral plane regex ranges using a sequence of two
ranges: one for each side of the surrogate pairs.

In this way astral plane regex can be represented without megabytes of
alternations.